### PR TITLE
Fixing a bug causing the library to skip words

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,5 +21,8 @@
     "psr-0": {
       "HtmlTruncator": "src/"
     }
+  },
+  "require-dev": {
+    "phpunit/phpunit": "4.4.*"
   }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,18 @@
+<phpunit
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    bootstrap="vendor/autoload.php"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    syntaxCheck="false"
+>
+    <testsuites>
+        <testsuite name="Library Test Suite">
+            <directory suffix=".php">./tests/</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/HtmlTruncator/Truncator.php
+++ b/src/HtmlTruncator/Truncator.php
@@ -133,12 +133,16 @@ class Truncator {
 				return array($xhtml, $count, $opts);
 			}
 			if (count($words) > 1) {
-				$content = array_reduce($words, function($result, $word) use ($length) {
-					if (strlen($result) + strlen($word) <= $length) {
-						$result .= $word;
+				$content = '';
+
+				foreach ($words as $word) {
+					if (strlen($content) + strlen($word) > $length) {
+						break;
 					}
-					return $result;
-				}, '');
+
+					$content .= $word;
+				}
+
 				return array($content, $count, $opts);
 			}
 			return array(substr($node->textContent, 0, $length), $count, $opts);

--- a/tests/htmltruncator.test.php
+++ b/tests/htmltruncator.test.php
@@ -1,10 +1,10 @@
 <?php
 
-require_once 'src/HtmlTruncator/truncator.php';
-
 use HtmlTruncator\Truncator;
 
 class HtmlTruncatorTest extends PHPUnit_Framework_TestCase {
+
+	protected $ellipsis = '…';
 
 	public function setup() {
 		$this->short_text = "<p>Foo <b>Bar</b> Baz</p>";
@@ -155,6 +155,18 @@ On 11/06/11 11:12, JP wrote:<br />
 <p>Foo bar baz</p>
 ";
 		$this->assertRegExp('/<img src="\/foo.png"/', Truncator::truncate($txt, 2));
+	}
+
+	public function testTruncateMethodDoesNotSkipWords()
+	{
+		$sample = '<p>The Arcus Foundation latest effort in support of legal issues.</p>';
+		$charLength = 30;
+
+		$result = Truncator::truncate($sample, $charLength, array('length_in_chars' => true));
+
+		$expectedResult = '<p>The Arcus Foundation latest'.$this->ellipsis.'</p>';
+
+		$this->assertSame($expectedResult, $result);
 	}
 }
 


### PR DESCRIPTION
I noticed that the library would skip a word which was going to exceed the character limit, but would add the next word as long as it was within the limit. 

For example:
```html
* string: 'The Arcus Foundation latest effort in support of legal issues.'
* length: 30
* result: '<p>The Arcus Foundation latest in...</p>'
* desired result: '<p>The Arcus Foundation latest...</p>'
```