### PR TITLE
Fix broken UTF8 when truncating with ellipsis

### DIFF
--- a/src/HtmlTruncator/Truncator.php
+++ b/src/HtmlTruncator/Truncator.php
@@ -141,7 +141,7 @@ class Truncator {
 			$inner .= $txt;
 			if ($remaining < 0) {
 				if (static::ellipsable($node)) {
-					$inner = preg_replace('/(?:[\s\pP]+|(?:&(?:[a-z]+|#[0-9]+);?))*$/', '', $inner).$opts['ellipsis'];
+					$inner = preg_replace('/(?:[\s\pP]+|(?:&(?:[a-z]+|#[0-9]+);?))*$/u', '', $inner).$opts['ellipsis'];
 					$opts['ellipsis'] = '';
 					$opts['was_truncated'] = true;
 				}

--- a/tests/htmltruncator.test.php
+++ b/tests/htmltruncator.test.php
@@ -224,7 +224,12 @@ On 11/06/11 11:12, JP wrote:<br />
 		$length = 22;
 		$result = Truncator::truncate($sample, $length, array('length_in_chars' => true));
 		$this->assertSame($expectedResult, $result);
-	}
 
+		$sample = "El cartel está iluminado con módulos de led blanco frío.";
+		$result = Truncator::truncate($sample, 21, ['length_in_chars' => true, 'ellipsis' => '']);
+		$this->assertEquals('El cartel está', $result);
+		$result = Truncator::truncate($sample, 21, ['length_in_chars' => true]);
+		$this->assertEquals('El cartel está…', $result);
+	}
 }
 


### PR DESCRIPTION
The [regular expression](https://github.com/judev/php-htmltruncator/blob/fc20b82fb2701aacfa2a13087cd9adf0ab00a076/src/HtmlTruncator/Truncator.php#L144) used to remove trailing punctuation before adding ellipsis cannot handle UTF-8 strings and sometimes  creates invalid UTF-8 sequences, causing incorrect results and DOMDocument errors:

```
DOMDocumentFragment::appendXML(): Entity: line 1: parser error : internal error: detected an error in element content
```

```
DOMDocumentFragment::appendXML(): Entity: line 1: parser error : Input is not proper UTF-8, indicate encoding !
Bytes: 0xC3 0xE2 0x80 0xA6
``` 
To solve this, this MR just adds the 'u' ([PCRE_UTF8](http://php.net/manual/en/reference.pcre.pattern.modifiers.php)) flag to that regular expression. Test case is included.