### PR TITLE
Run tests on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: php
+php:
+  - '5.4'
+  - '5.5'
+  - '5.6'
+  - '7.0'
+  - '7.1'
+install:
+  - composer install

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 PHP HTML Truncator
 ==================
 
+[![Build Status](https://api.travis-ci.org/judev/php-htmltruncator.svg)](https://travis-ci.org/judev/php-htmltruncator)
+
 This is a PHP port of the [html_truncator gem](https://github.com/nono/HTML-Truncator).
 
 It will cleanly truncate HTML content, appending an ellipsis or other marker in the most


### PR DESCRIPTION
This PR adds a basic `.travis.yml` to run PHPUNIT tests on TravisCI, using PHP versions 5.4-7.1.

You'll need to enable TravisCI for this project here: https://travis-ci.org/judev/php-htmltruncator